### PR TITLE
🐛 Fix: Remove loading text overlapping spinner

### DIFF
--- a/app/frontend/src/App.css
+++ b/app/frontend/src/App.css
@@ -14,7 +14,7 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 20px;
+  justify-content: center;
 }
 
 .spinner {
@@ -26,11 +26,7 @@
   animation: spin 1s linear infinite;
 }
 
-.loading-spinner p {
-  color: white;
-  font-size: 16px;
-  margin: 0;
-}
+/* Removed .loading-spinner p rule to prevent any text styling */
 
 @keyframes spin {
   0% { transform: rotate(0deg); }

--- a/app/frontend/src/App.tsx
+++ b/app/frontend/src/App.tsx
@@ -26,11 +26,12 @@ const AppContent: React.FC = () => {
   const { isAuthenticated, isLoading } = useAuth();
 
   if (isLoading) {
+    // IMPORTANT: Only show spinner, no text - this prevents text overlapping the spinner
+    // DO NOT add any <p> or text elements here - recurring bug fixed
     return (
       <div className="loading-container">
         <div className="loading-spinner">
           <div className="spinner"></div>
-          <p>Loading OrderNimbus...</p>
         </div>
       </div>
     );

--- a/tests/unit/loading-screen.test.js
+++ b/tests/unit/loading-screen.test.js
@@ -1,0 +1,74 @@
+/**
+ * Loading Screen Test
+ * 
+ * Purpose: Prevent regression of the loading screen bug where text appears on top of spinner
+ * Bug: "Loading OrderNimbus..." text was showing on top of the spinner
+ * Fix: Removed all text from loading screen, only show spinner
+ */
+
+const { expect } = require('chai');
+const fs = require('fs');
+const path = require('path');
+
+describe('Loading Screen Bug Prevention', () => {
+  const appTsxPath = path.join(__dirname, '../../app/frontend/src/App.tsx');
+  const appCssPath = path.join(__dirname, '../../app/frontend/src/App.css');
+
+  it('should not contain "Loading OrderNimbus" text in App.tsx', () => {
+    const appContent = fs.readFileSync(appTsxPath, 'utf8');
+    
+    // Check that the loading text has been removed
+    expect(appContent).to.not.include('Loading OrderNimbus');
+    expect(appContent).to.not.include('<p>Loading');
+    
+    // Ensure the loading container still exists
+    expect(appContent).to.include('loading-container');
+    expect(appContent).to.include('loading-spinner');
+    expect(appContent).to.include('spinner');
+  });
+
+  it('should have preventive comment in loading section', () => {
+    const appContent = fs.readFileSync(appTsxPath, 'utf8');
+    
+    // Check for the preventive comment
+    expect(appContent).to.include('IMPORTANT: Only show spinner, no text');
+    expect(appContent).to.include('DO NOT add any <p> or text elements here');
+  });
+
+  it('should not have loading text paragraph styles in CSS', () => {
+    const cssContent = fs.readFileSync(appCssPath, 'utf8');
+    
+    // Check that the paragraph style for loading text has been removed
+    expect(cssContent).to.not.include('.loading-spinner p {');
+    
+    // Ensure the spinner styles still exist
+    expect(cssContent).to.include('.loading-spinner');
+    expect(cssContent).to.include('.spinner');
+    expect(cssContent).to.include('@keyframes spin');
+  });
+
+  it('should have correct loading spinner structure', () => {
+    const appContent = fs.readFileSync(appTsxPath, 'utf8');
+    
+    // Extract the loading section (only the JSX part, not comments)
+    const loadingMatch = appContent.match(/return \(\s*<div className="loading-container">[\s\S]*?<\/div>\s*\)/);
+    expect(loadingMatch).to.not.be.null;
+    
+    const loadingJSX = loadingMatch[0];
+    
+    // Check structure: container > spinner wrapper > spinner only
+    expect(loadingJSX).to.include('loading-container');
+    expect(loadingJSX).to.include('loading-spinner');
+    expect(loadingJSX).to.include('spinner');
+    
+    // Ensure no paragraph or text elements in JSX
+    expect(loadingJSX).to.not.match(/<p>/);
+    expect(loadingJSX).to.not.match(/<p\s[^>]*>/);
+    expect(loadingJSX).to.not.match(/<span[^>]*>.*Loading/i);
+    expect(loadingJSX).to.not.match(/<h[1-6][^>]*>/);
+    
+    // Count div elements - should only be 3 (container, spinner wrapper, spinner)
+    const divCount = (loadingJSX.match(/<div/g) || []).length;
+    expect(divCount).to.equal(3);
+  });
+});


### PR DESCRIPTION
## Summary
This PR fixes the recurring bug where 'Loading OrderNimbus...' text was appearing on top of the loading spinner, creating a poor visual experience.

## Problem
- Text was showing on top of the spinner during initial page load
- Created an overlapping visual issue
- This was a recurring bug that needed permanent prevention

## Solution
- ✅ Removed the text element from the loading screen
- ✅ Only the spinner animation is now shown
- ✅ Cleaned up CSS to remove text styling
- ✅ Added preventive comments to avoid regression
- ✅ Created unit test to prevent this bug from recurring

## Changes Made
- **app/frontend/src/App.tsx**: Removed `<p>Loading OrderNimbus...</p>` element
- **app/frontend/src/App.css**: Removed paragraph styling for loading text
- **tests/unit/loading-screen.test.js**: Added comprehensive test suite to prevent regression

## Testing
- ✅ Built successfully with `npm run build`
- ✅ All unit tests passing (61 tests)
- ✅ New loading screen test passing (4 test cases)
- ✅ Pre-commit hooks validated
- ✅ Pre-push checks completed

## Prevention Measures
1. Added clear comments in the code warning against adding text
2. Created unit tests that will fail if text is added back
3. Removed CSS rules that styled the text

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Screenshots
**Before**: Text appearing on top of spinner
**After**: Clean spinner animation only

🤖 Generated with Claude Code

Co-Authored-By: Claude <noreply@anthropic.com>