### PR TITLE
🐛 Fix: Shopify sync 401 authentication error

### DIFF
--- a/app/frontend/src/components/ShopifyConnect.tsx
+++ b/app/frontend/src/components/ShopifyConnect.tsx
@@ -33,8 +33,21 @@ const ShopifyConnect: React.FC<ShopifyConnectProps> = ({ userId, onSuccess, onCa
         setTimeout(() => {
           const storeData = event.data.data || { 
             success: event.data.success, 
-            storeId: event.data.storeId 
+            storeId: event.data.storeId,
+            apiKey: event.data.apiKey,
+            accessToken: event.data.apiKey // Also set as accessToken for compatibility
           };
+          // Add the store domain we started with if not present
+          if (!storeData.shopifyDomain && storeDomain) {
+            storeData.shopifyDomain = storeDomain.includes('.myshopify.com') 
+              ? storeDomain 
+              : storeDomain + '.myshopify.com';
+          }
+          // Ensure API key is included
+          if (event.data.apiKey) {
+            storeData.apiKey = event.data.apiKey;
+            storeData.accessToken = event.data.apiKey;
+          }
           onSuccess(storeData);
         }, 1500);
       } else if (event.data.type === 'shopify-oauth-error') {

--- a/app/frontend/src/components/StoresPage.tsx
+++ b/app/frontend/src/components/StoresPage.tsx
@@ -303,7 +303,10 @@ const StoresPage: React.FC = () => {
         },
         body: JSON.stringify({
           userId: user?.userId || 'test-user',
-          storeDomain: storeData.storeDomain || storeData.shop
+          storeId: storeData.storeId || storeData.id,
+          shopifyDomain: storeData.shopifyDomain || storeData.storeDomain || storeData.shop,
+          apiKey: storeData.apiKey || storeData.accessToken,
+          syncType: 'full'
         })
       });
       

--- a/lambda/shopify-oauth.js
+++ b/lambda/shopify-oauth.js
@@ -299,6 +299,8 @@ const handleOAuthCallback = async (code, shop, state, hmac) => {
       success: true,
       storeId,
       storeName: shopInfo.name,
+      shopifyDomain: shop,
+      apiKey: accessToken,
       userId
     };
     


### PR DESCRIPTION
## Summary
This PR fixes the 401 authentication error that occurred when trying to sync Shopify stores after OAuth connection.

## Problem
After successfully connecting a Shopify store via OAuth, the subsequent sync operation would fail with a 401 error because:
- The API key (access token) was not being returned from the OAuth callback
- The frontend was not passing the required authentication data to the sync endpoint

## Solution
✅ **Backend Changes**:
- Modified `shopify-oauth.js` to return the `apiKey` (access token) in the OAuth callback response
- This ensures the frontend receives the authentication token needed for sync operations

✅ **Frontend Changes**:
- Updated `StoresPage.tsx` to pass `storeId`, `apiKey`, and `syncType` to the sync endpoint
- Modified `ShopifyConnect.tsx` to properly extract and pass the API key from OAuth response
- Added compatibility by setting both `apiKey` and `accessToken` fields

## Changes Made
- **lambda/shopify-oauth.js**: Return apiKey in OAuth callback response
- **app/frontend/src/components/StoresPage.tsx**: Pass authentication data to sync endpoint
- **app/frontend/src/components/ShopifyConnect.tsx**: Extract and forward API key from OAuth response

## Testing
- ✅ All 61 unit tests passing
- ✅ Frontend builds successfully
- ✅ Pre-commit and pre-push hooks pass

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Tests pass
- [x] No new warnings

🤖 Generated with Claude Code

Co-Authored-By: Claude <noreply@anthropic.com>