### PR TITLE
📚 Docs: Shopify redirect URI whitelist instructions

### DIFF
--- a/docs/SHOPIFY_APP_SETUP.md
+++ b/docs/SHOPIFY_APP_SETUP.md
@@ -1,0 +1,77 @@
+# Shopify App Setup Instructions
+
+## CRITICAL: Redirect URI Configuration
+
+The Shopify OAuth flow requires the redirect URI to be **exactly** whitelisted in your Shopify Partners Dashboard.
+
+### Current Production Redirect URI
+```
+https://p12brily0d.execute-api.us-west-1.amazonaws.com/production/api/shopify/callback
+```
+
+## How to Add Redirect URI to Shopify App
+
+1. **Log in to Shopify Partners Dashboard**
+   - Go to: https://partners.shopify.com
+   - Sign in with your partner account
+
+2. **Navigate to Your App**
+   - Click on "Apps" in the left sidebar
+   - Select your OrderNimbus app
+
+3. **Go to App Setup**
+   - Click on "Configuration" or "App setup" in the left menu
+
+4. **Add Redirect URI**
+   - Find the "App URL" or "Allowed redirection URL(s)" section
+   - Add this EXACT URL:
+   ```
+   https://p12brily0d.execute-api.us-west-1.amazonaws.com/production/api/shopify/callback
+   ```
+   - Make sure there are NO trailing slashes or extra spaces
+   - Save the changes
+
+5. **Verify the Configuration**
+   - The URL must match EXACTLY what the Lambda generates
+   - Check for typos or extra characters
+   - Ensure the save was successful
+
+## Important Notes
+
+⚠️ **The redirect URI must match EXACTLY** - even a trailing slash difference will cause the "invalid_request" error
+
+⚠️ **Multiple Environments**: If you have staging/development environments, add those redirect URIs too:
+- Staging: `https://YOUR_STAGING_API/staging/api/shopify/callback`
+- Development: `http://localhost:3001/api/shopify/callback`
+
+⚠️ **Dynamic Generation**: The Lambda dynamically generates this URI based on the API Gateway context, so it will always use the correct domain
+
+## Troubleshooting
+
+If you still get "The redirect_uri is not whitelisted" error:
+
+1. **Double-check the exact URL** being generated:
+   ```bash
+   curl -X POST https://p12brily0d.execute-api.us-west-1.amazonaws.com/production/api/shopify/connect \
+     -H "Content-Type: application/json" \
+     -d '{"userId":"test","storeDomain":"test.myshopify.com"}' \
+     -s | jq -r '.authUrl'
+   ```
+
+2. **Verify in Shopify Partners Dashboard** that the URL is saved correctly
+
+3. **Clear browser cache** and try again
+
+4. **Check for multiple apps** - make sure you're configuring the right app
+
+## Current App Credentials
+
+- **Client ID**: `d4599bc60ea67dabd0be7fccc10476d9`
+- **App Name**: OrderNimbus (or your configured app name)
+
+## Support
+
+If the issue persists after following these steps, check:
+- Shopify Partners Dashboard for any app suspension or issues
+- AWS CloudWatch logs for the exact redirect URI being generated
+- Ensure the Shopify app is approved and installed correctly

--- a/scripts/get-shopify-redirect-uri.sh
+++ b/scripts/get-shopify-redirect-uri.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+
+# Script to get the exact Shopify redirect URI that needs to be whitelisted
+# This URI must be added to your Shopify Partners Dashboard
+
+set -e
+
+# Color codes for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+echo "🔍 Fetching Shopify Redirect URI Configuration..."
+echo ""
+
+# Get the API Gateway URL
+API_URL="https://p12brily0d.execute-api.us-west-1.amazonaws.com/production"
+
+# Test the connect endpoint to get the actual redirect URI
+echo "Testing Shopify connect endpoint..."
+RESPONSE=$(curl -s -X POST "${API_URL}/api/shopify/connect" \
+  -H "Content-Type: application/json" \
+  -d '{"userId":"test","storeDomain":"test.myshopify.com"}')
+
+if [ $? -ne 0 ]; then
+  echo -e "${RED}❌ Failed to connect to API${NC}"
+  exit 1
+fi
+
+# Extract the redirect URI from the OAuth URL
+REDIRECT_URI=$(echo "$RESPONSE" | jq -r '.authUrl' | grep -o 'redirect_uri=[^&]*' | cut -d= -f2 | python3 -c "import sys, urllib.parse; print(urllib.parse.unquote(sys.stdin.read().strip()))")
+
+if [ -z "$REDIRECT_URI" ]; then
+  echo -e "${RED}❌ Could not extract redirect URI${NC}"
+  echo "Response: $RESPONSE"
+  exit 1
+fi
+
+echo ""
+echo -e "${GREEN}✅ Successfully retrieved redirect URI${NC}"
+echo ""
+echo "=========================================="
+echo -e "${YELLOW}SHOPIFY REDIRECT URI TO WHITELIST:${NC}"
+echo "=========================================="
+echo ""
+echo -e "${GREEN}$REDIRECT_URI${NC}"
+echo ""
+echo "=========================================="
+echo ""
+echo "📝 Instructions:"
+echo "1. Log in to Shopify Partners Dashboard: https://partners.shopify.com"
+echo "2. Navigate to your OrderNimbus app"
+echo "3. Go to 'App setup' or 'Configuration'"
+echo "4. Find 'Allowed redirection URL(s)' section"
+echo "5. Add the EXACT URL shown above (copy and paste it)"
+echo "6. Save the changes"
+echo ""
+echo "⚠️  IMPORTANT: The URL must match EXACTLY - no trailing slashes or extra spaces!"
+echo ""
+
+# Also check current Secrets Manager configuration
+echo "📦 Current Secrets Manager Configuration:"
+AWS_REGION=${AWS_REGION:-us-west-1}
+SECRET_VALUE=$(aws secretsmanager get-secret-value \
+  --secret-id ordernimbus/production/shopify \
+  --region "$AWS_REGION" \
+  --query SecretString \
+  --output text 2>/dev/null || echo "{}")
+
+if [ "$SECRET_VALUE" != "{}" ]; then
+  CLIENT_ID=$(echo "$SECRET_VALUE" | jq -r '.SHOPIFY_CLIENT_ID // "Not found"')
+  echo "Client ID: $CLIENT_ID"
+else
+  echo -e "${YELLOW}⚠️  Could not retrieve Shopify credentials from Secrets Manager${NC}"
+fi
+
+echo ""
+echo "✨ Once you've added the redirect URI to Shopify, the OAuth flow will work!"


### PR DESCRIPTION
## Summary
This PR provides documentation and tools to fix the Shopify OAuth 'redirect_uri is not whitelisted' error.

## Problem
Users are getting this error when trying to connect Shopify stores:
```
Oauth error invalid_request: The redirect_uri is not whitelisted
```

## Root Cause
The redirect URI generated by our Lambda function is not whitelisted in the Shopify Partners Dashboard. This is a **manual configuration** that must be done in Shopify's admin panel.

## Solution
✅ Created comprehensive documentation for whitelisting the redirect URI
✅ Added helper script to fetch the exact URI that needs whitelisting
✅ Documented the exact redirect URI for production

## The Redirect URI to Whitelist
```
https://p12brily0d.execute-api.us-west-1.amazonaws.com/production/api/shopify/callback
```

## How to Fix
1. Log in to [Shopify Partners Dashboard](https://partners.shopify.com)
2. Navigate to your OrderNimbus app
3. Go to 'App setup' or 'Configuration'
4. Find 'Allowed redirection URL(s)' section
5. Add the EXACT URL above (no trailing slashes)
6. Save the changes

## Files Added
- **docs/SHOPIFY_APP_SETUP.md**: Complete setup instructions
- **scripts/get-shopify-redirect-uri.sh**: Helper script to get the exact URI

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

🤖 Generated with Claude Code

Co-Authored-By: Claude <noreply@anthropic.com>