### PR TITLE
🐛 Fix: InventoryPage ConfigProvider context error

### DIFF
--- a/app/frontend/src/components/InventoryPage.tsx
+++ b/app/frontend/src/components/InventoryPage.tsx
@@ -5,7 +5,7 @@ import { ClipLoader } from 'react-spinners';
 import { FiRefreshCw, FiSearch, FiFilter, FiPackage, FiAlertTriangle, FiCheckCircle, FiPlus } from 'react-icons/fi';
 import ManualEntryModal from './ManualEntryModal';
 import './ManualEntryModal.css';
-import { useApiUrl } from '../contexts/ConfigContext';
+import { getApiUrl } from '../config/environment';
 
 interface InventoryItem {
   id: string;
@@ -39,7 +39,6 @@ interface Store {
 }
 
 const InventoryPage: React.FC = () => {
-  const apiUrl = useApiUrl();
   const [inventory, setInventory] = useState<InventoryItem[]>([]);
   const [stores, setStores] = useState<Store[]>([]);
   const [selectedStore, setSelectedStore] = useState<string>('');
@@ -63,7 +62,7 @@ const InventoryPage: React.FC = () => {
     try {
       const userId = localStorage.getItem('currentUserId') || 'e85183d0-3061-70b8-25f5-171fd848ac9d';
       
-      const response = await fetch(`${apiUrl}/api/stores`, {
+      const response = await fetch(`${getApiUrl()}/api/stores`, {
         headers: {
           'Content-Type': 'application/json',
           'userId': userId
@@ -95,7 +94,7 @@ const InventoryPage: React.FC = () => {
       // Always fetch from API - backend handles all data storage
       const userId = localStorage.getItem('currentUserId') || 'e85183d0-3061-70b8-25f5-171fd848ac9d';
       
-      const response = await fetch(`${apiUrl}/api/inventory?storeId=${selectedStore}`, {
+      const response = await fetch(`${getApiUrl()}/api/inventory?storeId=${selectedStore}`, {
         headers: {
           'Content-Type': 'application/json',
           'userId': userId
@@ -191,7 +190,7 @@ const InventoryPage: React.FC = () => {
     try {
       const userId = localStorage.getItem('currentUserId') || 'e85183d0-3061-70b8-25f5-171fd848ac9d';
       
-      const response = await fetch(`${apiUrl}/api/inventory`, {
+      const response = await fetch(`${getApiUrl()}/api/inventory`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',


### PR DESCRIPTION
## Summary
This PR fixes the React context error that was causing the Inventory page to crash with a blank page.

## Problem
When clicking on "Inventory" in the navigation, the page would show blank and throw this error:
```
Uncaught Error: useConfig must be used within a ConfigProvider
```

## Root Cause
The InventoryPage component was importing `useApiUrl` from `../contexts/ConfigContext`, which requires a ConfigProvider wrapper that doesn't exist in the app. All other components use `getApiUrl()` from `../config/environment` instead.

## Solution
✅ Replaced `useApiUrl` import with `getApiUrl` from environment
✅ Removed the `apiUrl` variable declaration
✅ Updated all API calls to use `getApiUrl()` directly
✅ Aligned InventoryPage with the pattern used by other components

## Changes Made
- **InventoryPage.tsx**: 
  - Changed import from `ConfigContext` to `environment`
  - Removed `const apiUrl = useApiUrl();`
  - Updated 3 API calls to use `getApiUrl()`

## Testing
- ✅ All 61 unit tests passing
- ✅ Built successfully
- ✅ Deployed to production
- ✅ Inventory page now loads without errors

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

🤖 Generated with Claude Code

Co-Authored-By: Claude <noreply@anthropic.com>