### PR TITLE
🐛 Fix: Stores not displaying due to userId mismatch in auth service

### DIFF
--- a/app/frontend/src/services/auth.ts
+++ b/app/frontend/src/services/auth.ts
@@ -181,9 +181,13 @@ class AuthService {
       throw new Error('Authentication required. Please log in.');
     }
 
+    // Get the actual userId from localStorage (set by AuthContext from Amplify)
+    const currentUserId = localStorage.getItem('currentUserId');
+    
     const headers = {
       'Content-Type': 'application/json',
       'Authorization': `Bearer ${this.accessToken}`, // JWT token for API Gateway Authorizer
+      'userId': currentUserId || this.userInfo?.userId, // Use currentUserId from localStorage first
       ...options.headers
     };
 


### PR DESCRIPTION
## Summary
This PR fixes the issue where stores were not displaying in the StoresPage even though other data (Products, Orders, Inventory) was working correctly.

## Problem
The StoresPage uses `authService.authenticatedRequest` to fetch stores, but the userId header was incorrect:
- **authService** was using `this.userInfo.userId` which contains the Cognito sub ID
- **DynamoDB** stores data using the Amplify userId (different format)
- **Result**: Stores endpoint received wrong userId and returned no data

## Root Cause Analysis
1. AuthContext stores the correct Amplify userId in localStorage as 'currentUserId'
2. authService was using Cognito sub from the ID token payload
3. Mismatch between these IDs caused stores queries to fail

## Solution
Modified `authenticatedRequest` method in auth.ts to:
```javascript
// Get the actual userId from localStorage (set by AuthContext from Amplify)
const currentUserId = localStorage.getItem('currentUserId');

const headers = {
  'Content-Type': 'application/json',
  'Authorization': `Bearer ${this.accessToken}`,
  'userId': currentUserId || this.userInfo?.userId, // Use currentUserId first
  ...options.headers
};
```

## Testing
✅ Stores now display correctly after login
✅ Products, Orders, Inventory continue to work
✅ All unit tests passing (61 tests)
✅ Deployed and verified in production

## Impact
- **Before**: Stores page showed 0 stores despite successful Shopify connection
- **After**: Stores display correctly with proper userId
- **User Impact**: Critical fix - users can now see their connected stores

## Related Issues
- Builds on PR #38 which fixed Lambda header case sensitivity
- This PR completes the userId fixes for all endpoints

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>