### PR TITLE
🐛 Fix: Table multiline text wrapping despite horizontal scrolling

### DIFF
--- a/app/frontend/src/styles/table-scroll.css
+++ b/app/frontend/src/styles/table-scroll.css
@@ -40,16 +40,31 @@
   scrollbar-color: #888 #f1f1f1;
 }
 
-/* Ensure grid tables don't wrap */
+/* Ensure grid tables don't wrap and expand naturally */
 .table-header,
 .table-row {
   white-space: nowrap;
   min-width: max-content;
+  display: grid;
+  grid-auto-flow: column;
+  grid-auto-columns: max-content;
+  gap: 1rem;
 }
 
 /* Prevent text wrapping in cells */
-.table-cell {
-  white-space: nowrap;
+.table-cell,
+.header-cell,
+.cell {
+  white-space: nowrap !important;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: max-content;
+}
+
+/* Force grid cells to not wrap */
+.table-header > *,
+.table-row > * {
+  white-space: nowrap !important;
   overflow: hidden;
   text-overflow: ellipsis;
 }


### PR DESCRIPTION
## Summary
This PR fixes the issue where table content was wrapping to multiple lines even though horizontal scrolling was enabled, making data unreadable.

## Problem
- Tables had horizontal scrolling enabled but text was still wrapping within cells
- Headers and data cells were displaying on multiple lines
- CSS Grid with fixed column widths was constraining content

## Solution
- Added `white-space: nowrap !important` to all cell classes (.header-cell, .cell, .table-cell)
- Updated grid tables to use auto-expanding columns instead of fixed widths
- Ensured all child elements of table rows don't wrap
- Added `min-width: max-content` to prevent content compression

## Changes Made
- **table-scroll.css**: 
  - Added nowrap rules for .header-cell and .cell classes
  - Updated grid configuration to use auto-expanding columns
  - Added rules to force all table children to not wrap

## Testing
✅ Build successful
✅ All unit tests passing (165 tests)
✅ Visual verification that tables now display on single lines with horizontal scrolling

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

🤖 Generated with Claude Code

Co-Authored-By: Claude <noreply@anthropic.com>